### PR TITLE
Connect rotation gizmo to active shape

### DIFF
--- a/MouseRotateTarget.cs
+++ b/MouseRotateTarget.cs
@@ -4,9 +4,13 @@ using UnityEngine;
 public class MouseRotateTarget : MonoBehaviour
 {
     public float rotationSpeed = 100f;
+    // Parent that contains the current shape prefab
+    public Transform rotator;
 
     private bool isSelected = false;
     private Camera mainCam;
+    // The object we actually rotate instead of the gizmo itself
+    private Transform target;
 
     void Start()
     {
@@ -15,10 +19,13 @@ public class MouseRotateTarget : MonoBehaviour
         {
             Debug.LogError("Main camera not found! Make sure your camera is tagged 'MainCamera'.");
         }
+        UpdateTargetFromRotator();
     }
 
     void Update()
     {
+        UpdateTargetFromRotator();
+
         if (Input.GetMouseButtonDown(0))
         {
             Ray ray = mainCam.ScreenPointToRay(Input.mousePosition);
@@ -32,13 +39,39 @@ public class MouseRotateTarget : MonoBehaviour
             }
         }
 
-        if (isSelected && Input.GetMouseButton(0))
+        if (isSelected && Input.GetMouseButton(0) && target != null)
         {
             float rotX = Input.GetAxis("Mouse X") * rotationSpeed * Time.deltaTime;
             float rotY = Input.GetAxis("Mouse Y") * rotationSpeed * Time.deltaTime;
 
-            transform.Rotate(mainCam.transform.up, -rotX, Space.World);
-            transform.Rotate(mainCam.transform.right, rotY, Space.World);
+            // Rotate the target object, keeping the gizmo itself fixed
+            target.Rotate(mainCam.transform.up, -rotX, Space.World);
+            target.Rotate(mainCam.transform.right, rotY, Space.World);
+        }
+    }
+
+    /// <summary>
+    /// Explicitly sets the object this gizmo controls.
+    /// </summary>
+    public void SetTarget(Transform newTarget)
+    {
+        target = newTarget;
+    }
+
+    // Keep track of the current object under the rotator, if available
+    void UpdateTargetFromRotator()
+    {
+        if (rotator != null && rotator.childCount > 0)
+        {
+            Transform newTarget = rotator.GetChild(0);
+            if (newTarget != target)
+            {
+                target = newTarget;
+            }
+        }
+        else if (rotator != null && rotator.childCount == 0)
+        {
+            target = null;
         }
     }
 }

--- a/Scripts/ShapeSequenceManager.cs
+++ b/Scripts/ShapeSequenceManager.cs
@@ -7,6 +7,8 @@ public class ShapeSequenceManager : MonoBehaviour
 {
     public Transform rotator;
     public TextMeshProUGUI cardText;
+    // Reference to the rotation gizmo so we can assign the active object
+    public MouseRotateTarget rotationGizmo;
 
     private Dictionary<string, string> shapeText = new Dictionary<string, string>();
     private List<string> shapeOrder = new List<string>();
@@ -76,6 +78,10 @@ public class ShapeSequenceManager : MonoBehaviour
         if (prefab != null && rotator != null)
         {
             currentShape = Instantiate(prefab, rotator.position, rotator.rotation, rotator);
+            if (rotationGizmo != null)
+            {
+                rotationGizmo.SetTarget(currentShape.transform);
+            }
         }
         else
         {


### PR DESCRIPTION
## Summary
- make `MouseRotateTarget` rotate an external target instead of itself
- support automatic target updates from the rotator object and expose `SetTarget`
- allow `ShapeSequenceManager` to inform the gizmo about the current shape

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ccfce5414832f8e851571d4300937