### PR TITLE
Add login scene with profile loading

### DIFF
--- a/Assets/Scenes/login.unity
+++ b/Assets/Scenes/login.unity
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1001}
+  - component: {fileID: 1002}
+  m_Layer: 0
+  m_Name: LoginManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57f09b352a5d4b67983edff5bb53b8e5, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  nextScene: legal disclaimer

--- a/Assets/Scenes/login.unity.meta
+++ b/Assets/Scenes/login.unity.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 3a2d7d8077684ef39ec76e65a7c97d43
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  assetImportInstructions:
+  - AI: 1

--- a/Assets/Scripts/LoginUI.cs
+++ b/Assets/Scripts/LoginUI.cs
@@ -1,0 +1,78 @@
+using System.IO;
+using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.SceneManagement;
+
+public class LoginUI : MonoBehaviour
+{
+    [SerializeField]
+    private string nextScene = "legal disclaimer";
+
+    InputField nameField;
+
+    void Start()
+    {
+        // Ensure a camera exists
+        if (Camera.main == null)
+        {
+            GameObject cam = new GameObject("Main Camera");
+            cam.tag = "MainCamera";
+            cam.AddComponent<Camera>();
+        }
+
+        // Setup canvas
+        GameObject canvasGO = new GameObject("Canvas");
+        Canvas canvas = canvasGO.AddComponent<Canvas>();
+        canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+        canvasGO.AddComponent<CanvasScaler>();
+        canvasGO.AddComponent<GraphicRaycaster>();
+
+        // Input field background
+        GameObject inputGO = new GameObject("NameInput");
+        inputGO.transform.SetParent(canvasGO.transform, false);
+        RectTransform inputRect = inputGO.AddComponent<RectTransform>();
+        inputRect.sizeDelta = new Vector2(200, 40);
+        Image inputImage = inputGO.AddComponent<Image>();
+        inputImage.color = Color.white;
+
+        // Input field component
+        nameField = inputGO.AddComponent<InputField>();
+        nameField.targetGraphic = inputImage;
+        Text textComp = CreateText("Text", inputGO.transform, "");
+        nameField.textComponent = textComp;
+        Text placeholder = CreateText("Placeholder", inputGO.transform, "Enter Name");
+        placeholder.color = new Color(0.5f, 0.5f, 0.5f, 0.75f);
+        nameField.placeholder = placeholder;
+
+        // Start button
+        GameObject buttonGO = new GameObject("StartButton");
+        buttonGO.transform.SetParent(canvasGO.transform, false);
+        RectTransform btnRect = buttonGO.AddComponent<RectTransform>();
+        btnRect.sizeDelta = new Vector2(200, 40);
+        btnRect.anchoredPosition = new Vector2(0, -60);
+        Image btnImage = buttonGO.AddComponent<Image>();
+        Button button = buttonGO.AddComponent<Button>();
+        button.targetGraphic = btnImage;
+        Text btnText = CreateText("Text", buttonGO.transform, "Start");
+        btnText.alignment = TextAnchor.MiddleCenter;
+        button.onClick.AddListener(OnStartClicked);
+    }
+
+    Text CreateText(string name, Transform parent, string value)
+    {
+        GameObject go = new GameObject(name);
+        go.transform.SetParent(parent, false);
+        Text txt = go.AddComponent<Text>();
+        txt.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+        txt.text = value;
+        txt.alignment = TextAnchor.MiddleLeft;
+        return txt;
+    }
+
+    void OnStartClicked()
+    {
+        string username = string.IsNullOrWhiteSpace(nameField.text) ? "Player" : nameField.text.Trim();
+        PlayerProfile.LoadOrCreate(username);
+        SceneManager.LoadScene(nextScene);
+    }
+}

--- a/Assets/Scripts/LoginUI.cs.meta
+++ b/Assets/Scripts/LoginUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 57f09b352a5d4b67983edff5bb53b8e5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/PlayerProfile.cs
+++ b/Assets/Scripts/PlayerProfile.cs
@@ -1,0 +1,42 @@
+using System;
+using System.IO;
+using UnityEngine;
+
+[Serializable]
+public class PlayerProfileData
+{
+    public string playerName;
+    public string uuid;
+    public string progress;
+}
+
+/// <summary>
+/// Provides access to the current player's profile across scenes.
+/// </summary>
+public static class PlayerProfile
+{
+    public static PlayerProfileData Current { get; private set; }
+
+    public static void LoadOrCreate(string username)
+    {
+        string dir = Path.Combine(Application.persistentDataPath, "Players");
+        string path = Path.Combine(dir, $"Player_{username}.json");
+        if (File.Exists(path))
+        {
+            string json = File.ReadAllText(path);
+            Current = JsonUtility.FromJson<PlayerProfileData>(json);
+        }
+        else
+        {
+            Directory.CreateDirectory(dir);
+            Current = new PlayerProfileData
+            {
+                playerName = username,
+                uuid = Guid.NewGuid().ToString(),
+                progress = string.Empty
+            };
+            string json = JsonUtility.ToJson(Current, true);
+            File.WriteAllText(path, json);
+        }
+    }
+}

--- a/Assets/Scripts/PlayerProfile.cs.meta
+++ b/Assets/Scripts/PlayerProfile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7d8fe3759d3e4f249bcdb74a9ed38456
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/EditorBuildSettings.asset
+++ b/EditorBuildSettings.asset
@@ -6,6 +6,9 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
+    path: Assets/Scenes/login.unity
+    guid: 3a2d7d8077684ef39ec76e65a7c97d43
+  - enabled: 1
     path: Assets/Scenes/legal disclaimer.unity
     guid: 3defad1ec180485099c5170dffa95516
   - enabled: 1


### PR DESCRIPTION
## Summary
- add `PlayerProfile` static class for storing player's data
- implement `LoginUI` script to create simple login UI
- create `login` scene referencing `LoginUI`
- update `EditorBuildSettings` to load `login` scene first

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685cdff28b74832fba5b1629f2b9d062