### PR TITLE
Add object swap helper

### DIFF
--- a/Scripts/DrawingObjectSwitcher.cs
+++ b/Scripts/DrawingObjectSwitcher.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+using TMPro;
+
+/// <summary>
+/// Simple helper that swaps drawing objects without reloading the scene.
+/// </summary>
+public class DrawingObjectSwitcher : MonoBehaviour
+{
+    public GameObject currentObject;
+    public Transform spawnPoint;
+    public TextMeshProUGUI objectLabel;
+
+    /// <summary>
+    /// Replaces the current drawing object with <paramref name="nextPrefab"/>.
+    /// </summary>
+    public void SwitchToNextObject(GameObject nextPrefab, string labelText)
+    {
+        if (currentObject != null)
+        {
+            Destroy(currentObject);
+        }
+
+        ClearCanvas();
+
+        if (nextPrefab != null && spawnPoint != null)
+        {
+            currentObject = Instantiate(nextPrefab, spawnPoint.position,
+                                        spawnPoint.rotation, spawnPoint);
+        }
+
+        if (objectLabel != null)
+        {
+            objectLabel.text = labelText;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `DrawingObjectSwitcher` to quickly swap the active drawing object without reloading scenes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685cf019d2a4832fa445d8e80cff4f66