### PR TITLE
Add rendering thumbnail support

### DIFF
--- a/Scripts/PromptChainManager.cs
+++ b/Scripts/PromptChainManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.IO;
 using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
@@ -19,13 +20,70 @@ public class PromptChainManager : MonoBehaviour
 {
     public TextMeshProUGUI promptText;
     public Button nextButton;
+    public Image renderingImageUI;
+
     private List<PromptPiece> promptPieces = new List<PromptPiece>();
     private List<string> promptChain = new List<string>();
+    private Dictionary<string, string> renderingLookup = new Dictionary<string, string>();
+
+    Dictionary<string, string> ParseReferenceJson(string json)
+    {
+        var dict = new Dictionary<string, string>();
+        if (string.IsNullOrEmpty(json))
+            return dict;
+
+        json = json.Trim().Trim('{', '}');
+        var entries = json.Split(new char[] { ',' }, System.StringSplitOptions.RemoveEmptyEntries);
+        foreach (var entry in entries)
+        {
+            var kv = entry.Split(new char[] { ':' }, 2);
+            if (kv.Length != 2)
+                continue;
+            string key = kv[0].Trim().Trim('"');
+            string value = kv[1].Trim().Trim('"');
+            dict[key] = value;
+        }
+        return dict;
+    }
+
+    void UpdateRenderingImage(string rendering)
+    {
+        if (renderingImageUI == null)
+            return;
+
+        if (string.IsNullOrEmpty(rendering))
+        {
+            renderingImageUI.gameObject.SetActive(false);
+            return;
+        }
+
+        if (renderingLookup.TryGetValue(rendering, out string file))
+        {
+            string path = System.IO.Path.Combine("RenderingSwatches", System.IO.Path.GetFileNameWithoutExtension(file));
+            Sprite sprite = Resources.Load<Sprite>(path);
+            if (sprite != null)
+            {
+                renderingImageUI.sprite = sprite;
+                renderingImageUI.gameObject.SetActive(true);
+                return;
+            }
+        }
+
+        // Hide if lookup or load failed
+        renderingImageUI.gameObject.SetActive(false);
+    }
 
     void Start()
     {
         string json = Resources.Load<TextAsset>("prompt_list").text;
         promptPieces = JsonUtilityWrapper.FromJsonList<PromptPiece>(json);
+
+        // Load the rendering reference dictionary
+        TextAsset refAsset = Resources.Load<TextAsset>("RenderingSwatches/rendering_reference");
+        if (refAsset != null)
+            renderingLookup = ParseReferenceJson(refAsset.text);
+        else
+            Debug.LogWarning("Rendering reference JSON not found under Resources/RenderingSwatches/");
 
         nextButton.onClick.AddListener(AddNextPromptPiece);
         AddNextPromptPiece(); // Start with one
@@ -47,6 +105,8 @@ public class PromptChainManager : MonoBehaviour
 
         if (!string.IsNullOrEmpty(piece.rendering))
             chunk += ". Cover it in " + piece.rendering.ToLower() + " \uD83D\uDDBC\uFE0F";
+
+        UpdateRenderingImage(piece.rendering);
 
         promptChain.Add(chunk);
         promptText.text = string.Join(" ", promptChain);


### PR DESCRIPTION
## Summary
- look up rendering thumbnails from RenderingSwatches
- show a sprite thumbnail in the prompt UI if a rendering exists

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_685da8ff2370832fad412b6afadded2b