### PR TITLE
Add vertical symmetry handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,21 @@ Press **New Sheet** to extend the paper without clearing previous drawings. The 
 4. Add a close or back button inside the Mess Hall and hook its `onClick` event to `ExitMessHall`.
 
 When entering the Mess Hall, all three objects are activated. Exiting hides them again.
+
+## Symmetry Handler
+
+Attach the `SymmetryHandler` component anywhere in your scene and assign the
+`SketchbookToolPanel` so it can read the `mirrorSymmetry` toggle. Use
+`GetMirroredPosition` when drawing a brush stroke to obtain the reflected
+location across the center of the drawing area.
+
+To convert pointer coordinates from screen space to the drawing area's local
+space use:
+
+```csharp
+Vector2 localPos;
+RectTransformUtility.ScreenPointToLocalPointInRectangle(
+    drawingArea, Input.mousePosition, canvas.worldCamera, out localPos);
+```
+
+Pass `localPos` to `GetMirroredPosition` to retrieve the mirrored position.

--- a/Scripts/SymmetryHandler.cs
+++ b/Scripts/SymmetryHandler.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+
+/// <summary>
+/// Computes mirrored brush positions when vertical symmetry is enabled.
+///
+/// Setup notes:
+/// - Add this component anywhere in your scene and assign <see cref="toolPanel"/>
+///   so the handler knows whether symmetry is active.
+/// - Convert pointer positions to the drawing area's local space using
+///   RectTransformUtility.ScreenPointToLocalPointInRectangle before calling
+///   <see cref="GetMirroredPosition"/>.
+/// </summary>
+public class SymmetryHandler : MonoBehaviour
+{
+    [Tooltip("Panel containing the mirrorSymmetry toggle")]
+    public SketchbookToolPanel toolPanel;
+
+    /// <summary>
+    /// Returns the mirrored position across the vertical center of
+    /// <paramref name="drawingArea"/> when symmetry is enabled.
+    /// The input coordinates must use the same local space as the RectTransform.
+    /// </summary>
+    public Vector2 GetMirroredPosition(Vector2 originalPosition, RectTransform drawingArea)
+    {
+        if (toolPanel != null && toolPanel.mirrorSymmetry && drawingArea != null)
+        {
+            Rect rect = drawingArea.rect;
+            float centerX = rect.xMin + rect.width * 0.5f;
+            float offset = originalPosition.x - centerX;
+            float mirroredX = centerX - offset;
+            return new Vector2(mirroredX, originalPosition.y);
+        }
+        return originalPosition;
+    }
+}


### PR DESCRIPTION
## Summary
- implement `SymmetryHandler` script to mirror brush strokes across the drawing area's center
- document how to convert pointer positions and use the handler

## Testing
- `echo "No tests"`

------
https://chatgpt.com/codex/tasks/task_e_685db53ff680832f8942f0749730a316