### PR TITLE
Integrate session tracker hooks

### DIFF
--- a/Scripts/DrawingObjectSwitcher.cs
+++ b/Scripts/DrawingObjectSwitcher.cs
@@ -12,6 +12,9 @@ public class DrawingObjectSwitcher : MonoBehaviour
     public Transform spawnPoint;
     public TextMeshProUGUI objectLabel;
 
+    [Header("Session Tracking")]
+    public MessHallSessionTracker sessionTracker;
+
     readonly HashSet<string> availableShapes = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
 
     void Awake()
@@ -74,6 +77,9 @@ public class DrawingObjectSwitcher : MonoBehaviour
         {
             objectLabel.text = labelText;
         }
+
+        if (sessionTracker != null && nextPrefab != null)
+            sessionTracker.AddShapeAsset(nextPrefab.name);
     }
 
     /// <summary>
@@ -119,5 +125,8 @@ public class DrawingObjectSwitcher : MonoBehaviour
         {
             objectLabel.text = shapeName;
         }
+
+        if (sessionTracker != null)
+            sessionTracker.AddShapeAsset(shapeName);
     }
 }

--- a/Scripts/LayerManager.cs
+++ b/Scripts/LayerManager.cs
@@ -7,8 +7,11 @@ using UnityEngine;
 /// </summary>
 public class LayerManager : MonoBehaviour
 {
-    [Tooltip("Drawing surfaces for Layer 1, Layer 2 and Layer 3.")]
+    [Tooltip("Drawing surfaces for Layer 1, Layer 2 and Layer 3.")] 
     public Texture[] layers = new Texture[3];
+
+    [Header("Session Tracking")]
+    public MessHallSessionTracker sessionTracker;
 
     int activeIndex;
 
@@ -18,6 +21,8 @@ public class LayerManager : MonoBehaviour
         if (index < 0 || index >= layers.Length)
             return;
         activeIndex = index;
+        if (sessionTracker != null)
+            sessionTracker.AddLayerUsed((index + 1).ToString());
     }
 
     /// <summary>Returns the texture currently targeted for drawing.</summary>

--- a/Scripts/MessHallCanvas.cs
+++ b/Scripts/MessHallCanvas.cs
@@ -28,6 +28,9 @@ public class MessHallCanvas : MonoBehaviour
 
     Vector2? lastPos;                      // Last recorded pen position
 
+    [Header("Session Tracking")]
+    public MessHallSessionTracker sessionTracker;
+
     void Awake()
     {
         if (newSheetButton != null)
@@ -138,6 +141,33 @@ public class MessHallCanvas : MonoBehaviour
         {
             lastPos = null;
         }
+    }
+
+    public void FlipCanvas()
+    {
+        if (content != null)
+        {
+            Vector3 scale = content.localScale;
+            scale.x *= -1f;
+            content.localScale = scale;
+        }
+        if (sessionTracker != null)
+            sessionTracker.RegisterCanvasFlip();
+    }
+
+    public void SetZoom(float zoom)
+    {
+        if (content != null)
+            content.localScale = Vector3.one * zoom;
+        if (sessionTracker != null)
+            sessionTracker.LogZoom(zoom);
+    }
+
+    public void Undo()
+    {
+        // Actual undo logic would go here
+        if (sessionTracker != null)
+            sessionTracker.RegisterUndo();
     }
 
     Vector2 GetTextureCoord(Vector2 screen)

--- a/Scripts/MessHallSessionTracker.cs
+++ b/Scripts/MessHallSessionTracker.cs
@@ -55,6 +55,20 @@ public class MessHallSessionTracker : MonoBehaviour
         data.totalDrawingTime += Time.deltaTime;
     }
 
+    /// <summary>
+    /// Update the currently active prompt ID.
+    /// </summary>
+    public void SetPromptID(string id)
+    {
+        if (!string.IsNullOrEmpty(id))
+            data.promptID = id;
+    }
+
+    /// <summary>
+    /// Toggle symmetry tracking state.
+    /// </summary>
+    public void SetSymmetry(bool enabled) => data.symmetryEnabled = enabled;
+
     /// <summary>Call once when the session begins.</summary>
     public void BeginSession(string promptId, bool symmetry, bool insightsConsent)
     {

--- a/Scripts/PromptChainManager.cs
+++ b/Scripts/PromptChainManager.cs
@@ -23,6 +23,9 @@ public class PromptChainManager : MonoBehaviour
     public Button nextButton;
     public Image renderingImageUI;
 
+    [Header("Session Tracking")]
+    public MessHallSessionTracker sessionTracker;
+
     // Phrases used when chaining prompts
     [SerializeField] private string[] generalConnectors = { "Then", "Next", "After that" };
     [SerializeField] private string[] spatialConnectors = { "Now", "Nearby", "Above it", "Below it" };
@@ -117,6 +120,8 @@ public class PromptChainManager : MonoBehaviour
             attempts++;
         } while (piece.shape == lastShape && attempts < 20);
         lastShape = piece.shape;
+        if (sessionTracker != null)
+            sessionTracker.SetPromptID(piece.shape);
 
         bool includeModifier = !string.IsNullOrEmpty(piece.modifier) && Random.value > 0.5f;
         bool includeDoodle = !string.IsNullOrEmpty(piece.doodle_addition) && Random.value > 0.5f;

--- a/Scripts/ShapeModifierHandler.cs
+++ b/Scripts/ShapeModifierHandler.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+using UnityEngine.Events;
+
+/// <summary>
+/// Example component that applies simple modifiers to a shape and logs
+/// the action to <see cref="MessHallSessionTracker"/>.
+/// </summary>
+public class ShapeModifierHandler : MonoBehaviour
+{
+    [Header("Session Tracking")] public MessHallSessionTracker sessionTracker;
+
+    [System.Serializable] public class ModifierEvent : UnityEvent<string> {}
+
+    public ModifierEvent onModifierApplied;
+
+    /// <summary>
+    /// Apply a modifier identified by <paramref name="tag"/>.
+    /// The actual modification of the GameObject is left to the user.
+    /// </summary>
+    public void ApplyModifier(string tag)
+    {
+        sessionTracker?.AddModifierTag(tag);
+        onModifierApplied?.Invoke(tag);
+    }
+}

--- a/Scripts/SketchbookToolPanel.cs
+++ b/Scripts/SketchbookToolPanel.cs
@@ -24,6 +24,9 @@ public class SketchbookToolPanel : MonoBehaviour
 {
     public enum SketchTool { Pencil, Ink, Airbrush, Eraser }
 
+    [Header("Session Tracking")]
+    public MessHallSessionTracker sessionTracker;
+
     [Header("UI References")]
     public Dropdown brushDropdown;
     public Slider sizeSlider;
@@ -86,12 +89,21 @@ public class SketchbookToolPanel : MonoBehaviour
         if (opacitySlider != null)
             opacitySlider.onValueChanged.AddListener(v => brushOpacity = v);
         if (symmetryToggle != null)
-            symmetryToggle.onValueChanged.AddListener(v => mirrorSymmetry = v);
+            symmetryToggle.onValueChanged.AddListener(OnSymmetryToggled);
     }
 
     public void OnBrushChanged(int index)
     {
         currentTool = (SketchTool)index;
+        if (sessionTracker != null)
+            sessionTracker.SwitchTool(currentTool.ToString());
+    }
+
+    void OnSymmetryToggled(bool value)
+    {
+        mirrorSymmetry = value;
+        if (sessionTracker != null)
+            sessionTracker.SetSymmetry(value);
     }
 
     public void OnLayerChanged(int index)
@@ -100,6 +112,8 @@ public class SketchbookToolPanel : MonoBehaviour
         if (formLayer != null) formLayer.SetActive(index == 0);
         if (inkLayer != null) inkLayer.SetActive(index == 1);
         if (lightLayer != null) lightLayer.SetActive(index == 2);
+        if (sessionTracker != null)
+            sessionTracker.AddLayerUsed((index + 1).ToString());
     }
 
     public void SetBrushColor(Color color)


### PR DESCRIPTION
## Summary
- expose `SetPromptID` and `SetSymmetry` on `MessHallSessionTracker`
- log tool, layer and symmetry changes from `SketchbookToolPanel`
- log prompts and shape usage
- track layer changes in `LayerManager`
- track canvas flips, zooms and undo actions
- add `ShapeModifierHandler` example

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_685dcd54fc9c832fbead856024e84414