### PR TITLE
Add Node.js server for Mess Hall session uploads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+MONGO_URI=mongodb+srv://user:password@cluster.mongodb.net/mydb

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -80,3 +80,15 @@ The exporter writes files to `Application.persistentDataPath` by default. Enable
 `saveToDesktop` to store images on the user's desktop instead. Filenames follow
 the pattern `messhall_sketch_###.png` or `.jpg` and automatically increment so
 existing files are not overwritten.
+
+## Session Upload Server
+
+A small Node.js + Express server receives session data from the Mess Hall and
+stores it in MongoDB Atlas.
+
+1. Copy `.env.example` to `.env` and fill in your `MONGO_URI`.
+2. Run `npm install` to install dependencies.
+3. Start the server with `node server.js`.
+
+The server listens on `/api/messhall/upload` and returns `{ "status": "ok" }`
+when data is successfully stored.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "messhall-server",
+  "version": "1.0.0",
+  "description": "Server to receive Mess Hall sessions",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.0.3",
+    "express": "^4.18.2",
+    "mongodb": "^5.7.0"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,46 @@
+const express = require('express');
+const cors = require('cors');
+const { MongoClient } = require('mongodb');
+require('dotenv').config();
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+// Allow CORS so Unity WebGL builds can communicate with the server
+app.use(cors());
+
+// Accept JSON bodies up to 1MB
+app.use(express.json({ limit: '1mb' }));
+
+let collection;
+async function init() {
+  if (!process.env.MONGO_URI) {
+    throw new Error('MONGO_URI is not defined in environment');
+  }
+  const client = new MongoClient(process.env.MONGO_URI, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true
+  });
+  await client.connect();
+  collection = client.db().collection('messhall_sessions');
+  console.log('Connected to MongoDB');
+}
+
+init().catch(err => {
+  console.error('Failed to initialize server:', err);
+  process.exit(1);
+});
+
+app.post('/api/messhall/upload', async (req, res) => {
+  try {
+    await collection.insertOne(req.body);
+    res.status(200).json({ status: 'ok' });
+  } catch (err) {
+    console.error('Insert failed:', err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- add `server.js` Express server for session uploads
- provide `.env.example` and `.gitignore`
- add `package.json` with dependencies
- document how to run the server in README

## Testing
- `npm install` *(fails: 403 Forbidden – registry access blocked)*
- `MONGO_URI=mongodb://localhost/test node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685dcedbf110832fb3712a808ef5d3f7