### PR TITLE
Compress Mess Hall session data

### DIFF
--- a/Scripts/MessHallSessionTracker.cs
+++ b/Scripts/MessHallSessionTracker.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.IO.Compression;
 using UnityEngine.Networking;
 using UnityEngine;
 
@@ -16,28 +17,58 @@ public class MessHallSessionTracker : MonoBehaviour
     [Serializable]
     class SessionData
     {
-        // Prompt & Setup
-        public string promptID = "none";
-        public List<string> shapeAssetsUsed = new List<string>();
-        public List<string> modifierTags = new List<string>();
-        public bool symmetryEnabled;
-        public List<string> layersUsed = new List<string>();
+        // Field name key:
+        // p  - promptID
+        // s  - shape codes (e.g. "cb" for cube)
+        // m  - modifier tags
+        // y  - symmetryEnabled
+        // l  - layers used
+        // t  - total drawing time
+        // a  - abandoned flag
+        // f  - canvas flip count
+        // z  - [zoom, timestamp] pairs
+        // u  - undo count
+        // ts - [from, to] tool switch pairs (Tools enum)
+        // d  - stroke density map
+        // sp - average stroke speed
+        // er - eraser volume
+        // fz - form zones
+        // sc - shape usage clusters
 
-        // Session Behaviour
-        public float totalDrawingTime;
-        public bool sessionAbandoned;
-        public int canvasFlipCount;
-        public List<float> zoomBehavior = new List<float>();
-        public int undoCount;
-        public List<string> toolSwitches = new List<string>();
+        public string p = "none";
+        public List<string> s = new List<string>();
+        public List<string> m = new List<string>();
+        public bool y;
+        public List<string> l = new List<string>();
 
-        // Drawing Insights
-        public int[][] strokeDensityMap;
-        public float avgStrokeSpeed;
-        public float eraserVolume;
-        public List<string> formZones = new List<string>();
-        public List<string> shapeUsageClusters = new List<string>();
+        public float t;
+        public bool a;
+        public int f;
+        public List<float[]> z = new List<float[]>();
+        public int u;
+        public List<int[]> ts = new List<int[]>();
+
+        public int[][] d;
+        public float sp;
+        public float er;
+        public List<string> fz = new List<string>();
+        public List<string> sc = new List<string>();
     }
+
+    // Tool enumeration used in compressed logs
+    enum Tools { Pencil = 0, Ink = 1, Airbrush = 2, Eraser = 3 }
+
+    // Map long shape names to compact two-letter codes for transmission
+    static readonly Dictionary<string, string> ShapeCodes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+        {"cube", "cb"},
+        {"sphere", "sp"},
+        {"cylinder", "cy"},
+        {"cone", "cn"},
+        {"pyramid", "py"},
+        {"tetrahedron", "th"},
+        {"octahedron", "oh"}
+    };
 
     const float AbandonThreshold = 0.05f; // <5% drawing considered abandoned
     const string DataFolder = "messhall_data";
@@ -50,8 +81,12 @@ public class MessHallSessionTracker : MonoBehaviour
     readonly SessionData data = new SessionData();
     DateTime startTime;
     bool consentGiven;
-    string lastTool;
+    Tools? lastTool;
     float activityRatio;
+    // When true the JSON payload is GZip compressed before upload.
+    // Backend example (Python/Flask):
+    //   data = gzip.decompress(request.data).decode('utf-8')
+    const bool UseGzip = true;
 
     void Start()
     {
@@ -60,7 +95,7 @@ public class MessHallSessionTracker : MonoBehaviour
 
     void Update()
     {
-        data.totalDrawingTime += Time.deltaTime;
+        data.t += Time.deltaTime;
     }
 
     /// <summary>
@@ -69,60 +104,71 @@ public class MessHallSessionTracker : MonoBehaviour
     public void SetPromptID(string id)
     {
         if (!string.IsNullOrEmpty(id))
-            data.promptID = id;
+            data.p = id;
     }
 
     /// <summary>
     /// Toggle symmetry tracking state.
     /// </summary>
-    public void SetSymmetry(bool enabled) => data.symmetryEnabled = enabled;
+    public void SetSymmetry(bool enabled) => data.y = enabled;
 
     /// <summary>Call once when the session begins.</summary>
     public void BeginSession(string promptId, bool symmetry, bool insightsConsent)
     {
-        data.promptID = string.IsNullOrEmpty(promptId) ? "none" : promptId;
-        data.symmetryEnabled = symmetry;
+        data.p = string.IsNullOrEmpty(promptId) ? "none" : promptId;
+        data.y = symmetry;
         consentGiven = insightsConsent;
     }
 
     /// <summary>Record the use of a shape asset.</summary>
     public void AddShapeAsset(string name)
     {
-        if (!string.IsNullOrEmpty(name) && !data.shapeAssetsUsed.Contains(name))
-            data.shapeAssetsUsed.Add(name);
+        if (string.IsNullOrEmpty(name))
+            return;
+        string code;
+        if (!ShapeCodes.TryGetValue(name, out code))
+            code = name.Length > 1 ? name.Substring(0, 2).ToLower() : name;
+        if (!data.s.Contains(code))
+            data.s.Add(code);
     }
 
     /// <summary>Record a modifier tag.</summary>
     public void AddModifierTag(string tag)
     {
-        if (!string.IsNullOrEmpty(tag) && !data.modifierTags.Contains(tag))
-            data.modifierTags.Add(tag);
+        if (!string.IsNullOrEmpty(tag) && !data.m.Contains(tag))
+            data.m.Add(tag);
     }
 
     /// <summary>Record that a layer was used.</summary>
     public void AddLayerUsed(string layer)
     {
-        if (!string.IsNullOrEmpty(layer) && !data.layersUsed.Contains(layer))
-            data.layersUsed.Add(layer);
+        if (!string.IsNullOrEmpty(layer) && !data.l.Contains(layer))
+            data.l.Add(layer);
     }
 
     /// <summary>Increment the canvas flip counter.</summary>
-    public void RegisterCanvasFlip() => data.canvasFlipCount++;
+    public void RegisterCanvasFlip() => data.f++;
 
     /// <summary>Record a zoom level.</summary>
-    public void LogZoom(float zoom) => data.zoomBehavior.Add(zoom);
+    public void LogZoom(float zoom)
+    {
+        float ts = (float)(DateTime.UtcNow - startTime).TotalSeconds;
+        data.z.Add(new float[] { zoom, ts });
+    }
 
     /// <summary>Increment undo count.</summary>
-    public void RegisterUndo() => data.undoCount++;
+    public void RegisterUndo() => data.u++;
 
     /// <summary>Record a tool switch.</summary>
     public void SwitchTool(string newTool)
     {
         if (string.IsNullOrEmpty(newTool))
             return;
-        if (lastTool != null && newTool != lastTool)
-            data.toolSwitches.Add($"{lastTool}\u2192{newTool}");
-        lastTool = newTool;
+        if (!Enum.TryParse(newTool, out Tools parsed))
+            return;
+        if (lastTool.HasValue && parsed != lastTool.Value)
+            data.ts.Add(new int[] { (int)lastTool.Value, (int)parsed });
+        lastTool = parsed;
     }
 
     /// <summary>Update drawing activity ratio (0..1).</summary>
@@ -137,25 +183,25 @@ public class MessHallSessionTracker : MonoBehaviour
     {
         if (!consentGiven)
             return;
-        data.strokeDensityMap = densityMap;
-        data.avgStrokeSpeed = avgSpeed;
-        data.eraserVolume = erasePct;
-        if (zones != null) data.formZones = new List<string>(zones);
-        if (clusters != null) data.shapeUsageClusters = new List<string>(clusters);
+        data.d = densityMap;
+        data.sp = avgSpeed;
+        data.er = erasePct;
+        if (zones != null) data.fz = new List<string>(zones);
+        if (clusters != null) data.sc = new List<string>(clusters);
     }
 
     /// <summary>Call when the session ends to write the JSON file.</summary>
     public void EndSession()
     {
-        data.sessionAbandoned = activityRatio < AbandonThreshold;
+        data.a = activityRatio < AbandonThreshold;
 
         if (!consentGiven)
         {
-            data.strokeDensityMap = null;
-            data.formZones.Clear();
-            data.shapeUsageClusters.Clear();
-            data.avgStrokeSpeed = 0f;
-            data.eraserVolume = 0f;
+            data.d = null;
+            data.fz.Clear();
+            data.sc.Clear();
+            data.sp = 0f;
+            data.er = 0f;
         }
 
         string dir = Path.Combine(Application.persistentDataPath, DataFolder);
@@ -171,11 +217,24 @@ public class MessHallSessionTracker : MonoBehaviour
     {
         string json = JsonUtility.ToJson(payload);
         byte[] body = Encoding.UTF8.GetBytes(json);
-        using (UnityWebRequest req = new UnityWebRequest(uploadUrl, "POST"))
+
+        if (UseGzip)
+        {
+            using (var ms = new MemoryStream())
+            {
+                using (var gz = new GZipStream(ms, CompressionLevel.Optimal))
+                    gz.Write(body, 0, body.Length);
+                body = ms.ToArray();
+            }
+        }
+
+        using (UnityWebRequest req = UnityWebRequest.Post(uploadUrl, ""))
         {
             req.uploadHandler = new UploadHandlerRaw(body);
             req.downloadHandler = new DownloadHandlerBuffer();
             req.SetRequestHeader("Content-Type", "application/json");
+            if (UseGzip)
+                req.SetRequestHeader("Content-Encoding", "gzip");
 
             yield return req.SendWebRequest();
 


### PR DESCRIPTION
## Summary
- shorten `SessionData` fields with letter aliases
- encode shapes and tools for compact logs
- gzip session JSON before upload
- document how to decode the payload on the backend

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685dd063a084832fbd93ec20bd433e31