### PR TITLE
Implement level 2 unlock support

### DIFF
--- a/Scripts/GameManager.cs
+++ b/Scripts/GameManager.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+
+public class GameManager : MonoBehaviour
+{
+    public enum Mode { Level1, MessHall, Level2 }
+
+    public static bool IsLevel2Unlocked { get; private set; }
+    public Mode ActiveMode { get; private set; }
+
+    public const string Level2Key = "Level2Unlocked";
+
+    public static event System.Action Level2Unlocked;
+
+    void Awake()
+    {
+        IsLevel2Unlocked = PlayerPrefs.GetInt(Level2Key, 0) == 1;
+    }
+
+    public void EnterLevel1()
+    {
+        ActiveMode = Mode.Level1;
+    }
+
+    public void EnterMessHall()
+    {
+        ActiveMode = Mode.MessHall;
+    }
+
+    public void EnterLevel2()
+    {
+        ActiveMode = Mode.Level2;
+    }
+
+    public void MarkLevel1Complete()
+    {
+        if (!IsLevel2Unlocked)
+        {
+            IsLevel2Unlocked = true;
+            PlayerPrefs.SetInt(Level2Key, 1);
+            PlayerPrefs.Save();
+            Level2Unlocked?.Invoke();
+        }
+    }
+}

--- a/Scripts/LevelStripManager.cs
+++ b/Scripts/LevelStripManager.cs
@@ -30,6 +30,16 @@ public class LevelStripManager : MonoBehaviour
             level2Button.onClick.AddListener(OnLevel2Clicked);
     }
 
+    void OnEnable()
+    {
+        GameManager.Level2Unlocked += OnLevel2Unlocked;
+    }
+
+    void OnDisable()
+    {
+        GameManager.Level2Unlocked -= OnLevel2Unlocked;
+    }
+
     void Start()
     {
         UpdateButtonStates();
@@ -46,6 +56,11 @@ public class LevelStripManager : MonoBehaviour
             if (img != null)
                 img.color = level2Unlocked ? normalColor : Color.gray;
         }
+    }
+
+    void OnLevel2Unlocked()
+    {
+        UpdateButtonStates();
     }
 
     void HighlightActiveButton()


### PR DESCRIPTION
## Summary
- add a `GameManager` class that remembers if level 2 is unlocked
- update `LevelStripManager` to refresh when level 2 becomes available

## Testing
- `npm test` *(fails: Missing script & no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_685de5c69b14832fa2655989c28e814a