### PR TITLE
Enable grammar switching for level 2

### DIFF
--- a/GameManager.cs
+++ b/GameManager.cs
@@ -1,0 +1,61 @@
+using System;
+using UnityEngine;
+
+public class GameManager : MonoBehaviour
+{
+    public enum Mode { Level1, MessHall, Level2 }
+
+    public static GameManager Instance { get; private set; }
+
+    public Mode ActiveMode { get; private set; } = Mode.Level1;
+    public bool IsLevel2Unlocked = true;
+
+    public static event Action OnGrammarChanged;
+
+    void Awake()
+    {
+        if (Instance == null)
+        {
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+        else if (Instance != this)
+        {
+            Destroy(gameObject);
+        }
+    }
+
+    public void EnterLevel1()
+    {
+        ActiveMode = Mode.Level1;
+        OnGrammarChanged?.Invoke();
+    }
+
+    public void EnterMessHall()
+    {
+        ActiveMode = Mode.MessHall;
+    }
+
+    public void EnterLevel2()
+    {
+        if (!IsLevel2Unlocked)
+            return;
+        ActiveMode = Mode.Level2;
+        OnGrammarChanged?.Invoke();
+    }
+
+    public string GetCardsDataPath()
+    {
+        return ActiveMode == Mode.Level2 ? "grammer2/level2_shape_grammar_cards" : "Data/shape_grammar_cards";
+    }
+
+    public string GetShapePrefabPath(string shapeName)
+    {
+        if (ActiveMode == Mode.Level2)
+        {
+            string sanitized = shapeName.ToLower().Replace(" + ", " on ");
+            return "grammer2/" + sanitized;
+        }
+        return "the" + shapeName.ToLower();
+    }
+}

--- a/Scripts/DrawingObjectSwitcher.cs
+++ b/Scripts/DrawingObjectSwitcher.cs
@@ -20,12 +20,19 @@ public class DrawingObjectSwitcher : MonoBehaviour
     void Awake()
     {
         LoadShapeNames();
+        GameManager.OnGrammarChanged += LoadShapeNames;
+    }
+
+    void OnDestroy()
+    {
+        GameManager.OnGrammarChanged -= LoadShapeNames;
     }
 
     void LoadShapeNames()
     {
         availableShapes.Clear();
-        TextAsset data = Resources.Load<TextAsset>("Data/shape_grammar_cards");
+        string path = GameManager.Instance != null ? GameManager.Instance.GetCardsDataPath() : "Data/shape_grammar_cards";
+        TextAsset data = Resources.Load<TextAsset>(path);
         if (data == null)
             return;
 
@@ -100,7 +107,7 @@ public class DrawingObjectSwitcher : MonoBehaviour
             return;
         }
 
-        string prefabName = "the" + lookup;
+        string prefabName = GameManager.Instance != null ? GameManager.Instance.GetShapePrefabPath(shapeName) : ("the" + lookup);
         GameObject prefab = Resources.Load<GameObject>(prefabName);
         if (prefab == null)
         {

--- a/Scripts/ShapeSequenceManager.cs
+++ b/Scripts/ShapeSequenceManager.cs
@@ -20,6 +20,7 @@ public class ShapeSequenceManager : MonoBehaviour
     void Start()
     {
         LoadShapeData();
+        GameManager.OnGrammarChanged += ReloadGrammar;
 
         // If the rotation gizmo wasn't assigned in the inspector, try to
         // locate it in the scene by name so we can still rotate new shapes
@@ -51,12 +52,18 @@ public class ShapeSequenceManager : MonoBehaviour
         SetupTextCard();
     }
 
+    void OnDestroy()
+    {
+        GameManager.OnGrammarChanged -= ReloadGrammar;
+    }
+
     void LoadShapeData()
     {
-        TextAsset data = Resources.Load<TextAsset>("Data/shape_grammar_cards");
+        string path = GameManager.Instance != null ? GameManager.Instance.GetCardsDataPath() : "Data/shape_grammar_cards";
+        TextAsset data = Resources.Load<TextAsset>(path);
         if (data == null)
         {
-            Debug.LogError("shape_grammar_cards.csv not found in Resources/Data");
+            Debug.LogError($"{path}.csv not found in Resources");
             return;
         }
 
@@ -97,7 +104,8 @@ public class ShapeSequenceManager : MonoBehaviour
             Destroy(currentShape);
         }
 
-        GameObject prefab = Resources.Load<GameObject>($"Prefabs/Shapes/Shape_{name}");
+        string prefabPath = GameManager.Instance != null ? GameManager.Instance.GetShapePrefabPath(name) : $"Prefabs/Shapes/Shape_{name}";
+        GameObject prefab = Resources.Load<GameObject>(prefabPath);
         if (prefab != null && rotator != null)
         {
             currentShape = Instantiate(prefab, rotator.position, rotator.rotation, rotator);
@@ -116,6 +124,15 @@ public class ShapeSequenceManager : MonoBehaviour
             cardText.enableAutoSizing = true;
             cardText.text = text;
         }
+    }
+
+    void ReloadGrammar()
+    {
+        shapeText.Clear();
+        shapeOrder.Clear();
+        currentIndex = 0;
+        LoadShapeData();
+        ShowShape(currentIndex);
     }
 
     public void ShowNextShape()


### PR DESCRIPTION
## Summary
- add new `GameManager` to track current mode and grammar
- reload shape data when grammar changes
- update drawing object switcher and sequence manager to use grammar paths

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685de702384c832f8e42b63017da1d3d