### PR TITLE
Add Passage 2 completion UI

### DIFF
--- a/GameManager.cs
+++ b/GameManager.cs
@@ -3,14 +3,16 @@ using UnityEngine;
 
 public class GameManager : MonoBehaviour
 {
-    public enum Mode { Level1, MessHall, Level2 }
+    public enum Mode { Level1, MessHall, Level2, Level3 }
 
     public static GameManager Instance { get; private set; }
 
     public Mode ActiveMode { get; private set; } = Mode.Level1;
     public bool IsLevel2Unlocked = true;
+    public bool IsLevel3Unlocked = false;
 
     public static event Action OnGrammarChanged;
+    public static event Action Level3Unlocked;
 
     void Awake()
     {
@@ -44,6 +46,14 @@ public class GameManager : MonoBehaviour
         OnGrammarChanged?.Invoke();
     }
 
+    public void EnterLevel3()
+    {
+        if (!IsLevel3Unlocked)
+            return;
+        ActiveMode = Mode.Level3;
+        OnGrammarChanged?.Invoke();
+    }
+
     public string GetCardsDataPath()
     {
         return ActiveMode == Mode.Level2 ? "grammer2/level2_shape_grammar_cards" : "Data/shape_grammar_cards";
@@ -57,5 +67,14 @@ public class GameManager : MonoBehaviour
             return "grammer2/" + sanitized;
         }
         return "the" + shapeName.ToLower();
+    }
+
+    public void MarkLevel2Complete()
+    {
+        if (!IsLevel3Unlocked)
+        {
+            IsLevel3Unlocked = true;
+            Level3Unlocked?.Invoke();
+        }
     }
 }

--- a/Scripts/GameManager.cs
+++ b/Scripts/GameManager.cs
@@ -2,18 +2,22 @@ using UnityEngine;
 
 public class GameManager : MonoBehaviour
 {
-    public enum Mode { Level1, MessHall, Level2 }
+    public enum Mode { Level1, MessHall, Level2, Level3 }
 
     public static bool IsLevel2Unlocked { get; private set; }
+    public static bool IsLevel3Unlocked { get; private set; }
     public Mode ActiveMode { get; private set; }
 
     public const string Level2Key = "Level2Unlocked";
+    public const string Level3Key = "Level3Unlocked";
 
     public static event System.Action Level2Unlocked;
+    public static event System.Action Level3Unlocked;
 
     void Awake()
     {
         IsLevel2Unlocked = PlayerPrefs.GetInt(Level2Key, 0) == 1;
+        IsLevel3Unlocked = PlayerPrefs.GetInt(Level3Key, 0) == 1;
     }
 
     public void EnterLevel1()
@@ -31,6 +35,11 @@ public class GameManager : MonoBehaviour
         ActiveMode = Mode.Level2;
     }
 
+    public void EnterLevel3()
+    {
+        ActiveMode = Mode.Level3;
+    }
+
     public void MarkLevel1Complete()
     {
         if (!IsLevel2Unlocked)
@@ -39,6 +48,17 @@ public class GameManager : MonoBehaviour
             PlayerPrefs.SetInt(Level2Key, 1);
             PlayerPrefs.Save();
             Level2Unlocked?.Invoke();
+        }
+    }
+
+    public void MarkLevel2Complete()
+    {
+        if (!IsLevel3Unlocked)
+        {
+            IsLevel3Unlocked = true;
+            PlayerPrefs.SetInt(Level3Key, 1);
+            PlayerPrefs.Save();
+            Level3Unlocked?.Invoke();
         }
     }
 }

--- a/Scripts/LevelStripManager.cs
+++ b/Scripts/LevelStripManager.cs
@@ -12,6 +12,7 @@ public class LevelStripManager : MonoBehaviour
     public Button level1Button;
     public Button messHallButton;
     public Button level2Button;
+    public Button level3Button;
 
     [Header("Passage 2 Intro")]
     public Passage2IntroUI passage2Intro;
@@ -31,16 +32,20 @@ public class LevelStripManager : MonoBehaviour
             messHallButton.onClick.AddListener(OnMessHallClicked);
         if (level2Button != null)
             level2Button.onClick.AddListener(OnLevel2Clicked);
+        if (level3Button != null)
+            level3Button.onClick.AddListener(OnLevel3Clicked);
     }
 
     void OnEnable()
     {
         GameManager.Level2Unlocked += OnLevel2Unlocked;
+        GameManager.Level3Unlocked += OnLevel3Unlocked;
     }
 
     void OnDisable()
     {
         GameManager.Level2Unlocked -= OnLevel2Unlocked;
+        GameManager.Level3Unlocked -= OnLevel3Unlocked;
     }
 
     void Start()
@@ -52,6 +57,7 @@ public class LevelStripManager : MonoBehaviour
     public void UpdateButtonStates()
     {
         bool level2Unlocked = gameManager != null && gameManager.IsLevel2Unlocked;
+        bool level3Unlocked = gameManager != null && gameManager.IsLevel3Unlocked;
         if (level2Button != null)
         {
             level2Button.interactable = level2Unlocked;
@@ -59,9 +65,21 @@ public class LevelStripManager : MonoBehaviour
             if (img != null)
                 img.color = level2Unlocked ? normalColor : Color.gray;
         }
+        if (level3Button != null)
+        {
+            level3Button.interactable = level3Unlocked;
+            Image img = level3Button.GetComponent<Image>();
+            if (img != null)
+                img.color = level3Unlocked ? normalColor : Color.gray;
+        }
     }
 
     void OnLevel2Unlocked()
+    {
+        UpdateButtonStates();
+    }
+
+    void OnLevel3Unlocked()
     {
         UpdateButtonStates();
     }
@@ -74,6 +92,7 @@ public class LevelStripManager : MonoBehaviour
         SetButtonColor(level1Button, gameManager.ActiveMode == GameManager.Mode.Level1);
         SetButtonColor(messHallButton, gameManager.ActiveMode == GameManager.Mode.MessHall);
         SetButtonColor(level2Button, gameManager.ActiveMode == GameManager.Mode.Level2);
+        SetButtonColor(level3Button, gameManager.ActiveMode == GameManager.Mode.Level3);
     }
 
     void SetButtonColor(Button button, bool active)
@@ -115,6 +134,15 @@ public class LevelStripManager : MonoBehaviour
                 gameManager.EnterLevel2();
                 HighlightActiveButton();
             }
+        }
+    }
+
+    void OnLevel3Clicked()
+    {
+        if (gameManager != null && gameManager.IsLevel3Unlocked)
+        {
+            gameManager.EnterLevel3();
+            HighlightActiveButton();
         }
     }
 }

--- a/Scripts/Passage2CompleteUI.cs
+++ b/Scripts/Passage2CompleteUI.cs
@@ -1,0 +1,120 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Displays an outro message after finishing Passage 2.
+/// Unlocks Passage 3 when the continue button is pressed.
+/// </summary>
+public class Passage2CompleteUI : MonoBehaviour
+{
+    [Tooltip("Reference to the level strip UI")]
+    public LevelStripManager levelStrip;
+
+    GameObject panel;
+
+    void Start()
+    {
+        CreatePanel();
+        panel.SetActive(false);
+    }
+
+    void CreatePanel()
+    {
+        Canvas canvas = FindObjectOfType<Canvas>();
+        if (canvas == null)
+        {
+            GameObject canvasGO = new GameObject("Canvas", typeof(Canvas), typeof(CanvasScaler), typeof(GraphicRaycaster));
+            canvas = canvasGO.GetComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+        }
+
+        panel = new GameObject("Passage2CompletePanel", typeof(RectTransform), typeof(Image));
+        panel.transform.SetParent(canvas.transform, false);
+        RectTransform rt = panel.GetComponent<RectTransform>();
+        rt.anchorMin = Vector2.zero;
+        rt.anchorMax = Vector2.one;
+        rt.offsetMin = Vector2.zero;
+        rt.offsetMax = Vector2.zero;
+
+        Image bg = panel.GetComponent<Image>();
+        bg.color = new Color(0f, 0f, 0f, 0.85f);
+
+        // Title
+        GameObject titleGO = new GameObject("Title", typeof(Text));
+        titleGO.transform.SetParent(panel.transform, false);
+        Text title = titleGO.GetComponent<Text>();
+        title.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+        title.fontSize = 32;
+        title.alignment = TextAnchor.UpperCenter;
+        title.color = Color.white;
+        title.text = "End of Passage Two";
+        RectTransform titleRT = title.GetComponent<RectTransform>();
+        titleRT.anchorMin = new Vector2(0.5f, 0.75f);
+        titleRT.anchorMax = new Vector2(0.5f, 0.75f);
+        titleRT.anchoredPosition = Vector2.zero;
+        titleRT.sizeDelta = new Vector2(800f, 60f);
+
+        // Body text
+        GameObject bodyGO = new GameObject("Body", typeof(Text));
+        bodyGO.transform.SetParent(panel.transform, false);
+        Text body = bodyGO.GetComponent<Text>();
+        body.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+        body.fontSize = 24;
+        body.alignment = TextAnchor.MiddleCenter;
+        body.color = Color.white;
+        body.text = "Now you understand shapes inside and out, from every angle, and can combine them like a pro. Passage Three is about transforming them.";
+        RectTransform bodyRT = body.GetComponent<RectTransform>();
+        bodyRT.anchorMin = new Vector2(0.5f, 0.5f);
+        bodyRT.anchorMax = new Vector2(0.5f, 0.5f);
+        bodyRT.anchoredPosition = Vector2.zero;
+        bodyRT.sizeDelta = new Vector2(800f, 150f);
+
+        // Continue button
+        GameObject buttonGO = new GameObject("ContinueButton", typeof(RectTransform), typeof(Image), typeof(Button));
+        buttonGO.transform.SetParent(panel.transform, false);
+        RectTransform buttonRT = buttonGO.GetComponent<RectTransform>();
+        buttonRT.anchorMin = new Vector2(0.5f, 0.15f);
+        buttonRT.anchorMax = new Vector2(0.5f, 0.15f);
+        buttonRT.anchoredPosition = Vector2.zero;
+        buttonRT.sizeDelta = new Vector2(180f, 40f);
+
+        GameObject textGO = new GameObject("Text", typeof(Text));
+        textGO.transform.SetParent(buttonGO.transform, false);
+        Text btnText = textGO.GetComponent<Text>();
+        btnText.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+        btnText.alignment = TextAnchor.MiddleCenter;
+        btnText.color = Color.black;
+        btnText.text = "On to passage 3";
+        btnText.fontSize = 24;
+        RectTransform btnTextRT = btnText.GetComponent<RectTransform>();
+        btnTextRT.anchorMin = Vector2.zero;
+        btnTextRT.anchorMax = Vector2.one;
+        btnTextRT.offsetMin = Vector2.zero;
+        btnTextRT.offsetMax = Vector2.zero;
+
+        Button btn = buttonGO.GetComponent<Button>();
+        btn.onClick.AddListener(OnContinueClicked);
+    }
+
+    public void Show()
+    {
+        if (panel == null)
+            CreatePanel();
+        panel.SetActive(true);
+    }
+
+    void OnContinueClicked()
+    {
+        if (panel != null)
+            panel.SetActive(false);
+
+        GameManager gm = FindObjectOfType<GameManager>();
+        if (gm != null)
+        {
+            gm.MarkLevel2Complete();
+        }
+
+        if (levelStrip != null)
+            levelStrip.UpdateButtonStates();
+    }
+}

--- a/Scripts/ShapeSequenceManager.cs
+++ b/Scripts/ShapeSequenceManager.cs
@@ -15,6 +15,9 @@ public class ShapeSequenceManager : MonoBehaviour
     [Header("Passage 1 Outro")]
     public Passage1CompleteUI passage1Complete;
 
+    [Header("Passage 2 Outro")]
+    public Passage2CompleteUI passage2Complete;
+
     private Dictionary<string, string> shapeText = new Dictionary<string, string>();
     private List<string> shapeOrder = new List<string>();
     private int currentIndex = 0;
@@ -144,7 +147,13 @@ public class ShapeSequenceManager : MonoBehaviour
             return;
         if (currentIndex >= shapeOrder.Count - 1)
         {
-            if (passage1Complete != null)
+            if (GameManager.Instance != null &&
+                GameManager.Instance.ActiveMode == GameManager.Mode.Level2 &&
+                passage2Complete != null)
+            {
+                passage2Complete.Show();
+            }
+            else if (passage1Complete != null)
             {
                 passage1Complete.Show();
             }


### PR DESCRIPTION
## Summary
- add panel for finishing passage 2
- unlock passage 3 when the continue button is pressed
- extend `GameManager` with level 3 support
- update level strip manager for new button
- trigger passage 2 completion panel in shape sequence manager

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685def938c88832fa3831224e98189e3